### PR TITLE
Strict types for `deepMerge` second argument

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -3,8 +3,6 @@ import {deepMerge} from "./index.ts";
 test("deepMerge", () => {
   expect(deepMerge({a: [1]}, null)).toEqual({a: [1]});
   expect(deepMerge({a: [1]}, undefined)).toEqual({a: [1]});
-  expect(deepMerge(null!, {a: [1]})).toEqual(null);
-  expect(deepMerge(undefined!, {a: [1]})).toEqual(undefined);
 
   expect(deepMerge({a: [1]}, {a: [2]})).toEqual({a: [2]});
   expect(deepMerge({a: [1]}, {a: [2]})).toEqual({a: [2]});
@@ -54,14 +52,12 @@ test("deepMerge", () => {
 
   expect(deepMerge([1], [2])).toEqual([2]);
   expect(deepMerge([1], [2], {arrayExtend: true})).toEqual([1, 2]);
-  expect(deepMerge([1], {})).toEqual({});
-  expect(deepMerge({}, [1])).toEqual([1]);
   expect(deepMerge({}, {})).toEqual({});
 
-  const original = {a: 1, deep: {b: 2}};
+  const original = {a: 1, deep: {b: 2, c: 0}};
   const result = deepMerge(original, {a: 2, deep: {c: 3}}, {clone: true});
   expect(result).toEqual({a: 2, deep: {b: 2, c: 3}});
-  expect(original).toEqual({a: 1, deep: {b: 2}});
+  expect(original).toEqual({a: 1, deep: {b: 2, c: 0}});
 
   const originalArr = [1, 2];
   const resultArr = deepMerge(originalArr, [3, 4], {clone: true, arrayExtend: true});
@@ -69,8 +65,17 @@ test("deepMerge", () => {
   expect(originalArr).toEqual([1, 2]);
 
   const customClone = (value: any) => structuredClone(value);
-  const original2 = {a: 1, deep: {b: 2}};
+  const original2 = {a: 1, deep: {b: 2, c: 0}};
   const result2 = deepMerge(original2, {a: 2, deep: {c: 3}}, {clone: customClone});
   expect(result2).toEqual({a: 2, deep: {b: 2, c: 3}});
-  expect(original2).toEqual({a: 1, deep: {b: 2}});
+  expect(original2).toEqual({a: 1, deep: {b: 2, c: 0}});
+});
+
+test("deepMerge type: rejects keys not in target", () => {
+  type Config = {pin?: Record<string, string>};
+  const config: Config = {pin: {tsdown: "0.21.9"}};
+  // @ts-expect-error 'pnpm' is not a key of Config
+  deepMerge(config, {pnpm: "^10"});
+  // @ts-expect-error 'wrongKey' is not a key of nested target
+  deepMerge({a: 1, deep: {b: 2}}, {deep: {wrongKey: 3}});
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -3,6 +3,10 @@ import {deepMerge} from "./index.ts";
 test("deepMerge", () => {
   expect(deepMerge({a: [1]}, null)).toEqual({a: [1]});
   expect(deepMerge({a: [1]}, undefined)).toEqual({a: [1]});
+  // @ts-expect-error null is not a valid destination
+  expect(deepMerge(null, {a: [1]})).toEqual(null);
+  // @ts-expect-error undefined is not a valid destination
+  expect(deepMerge(undefined, {a: [1]})).toEqual(undefined);
 
   expect(deepMerge({a: [1]}, {a: [2]})).toEqual({a: [2]});
   expect(deepMerge({a: [1]}, {a: [2]})).toEqual({a: [2]});
@@ -52,12 +56,16 @@ test("deepMerge", () => {
 
   expect(deepMerge([1], [2])).toEqual([2]);
   expect(deepMerge([1], [2], {arrayExtend: true})).toEqual([1, 2]);
+  // @ts-expect-error heterogeneous merge of array into object
+  expect(deepMerge([1], {})).toEqual({});
+  expect(deepMerge({}, [1])).toEqual([1]);
   expect(deepMerge({}, {})).toEqual({});
 
-  const original = {a: 1, deep: {b: 2, c: 0}};
+  const original = {a: 1, deep: {b: 2}};
+  // @ts-expect-error 'c' is not a key of `deep`
   const result = deepMerge(original, {a: 2, deep: {c: 3}}, {clone: true});
   expect(result).toEqual({a: 2, deep: {b: 2, c: 3}});
-  expect(original).toEqual({a: 1, deep: {b: 2, c: 0}});
+  expect(original).toEqual({a: 1, deep: {b: 2}});
 
   const originalArr = [1, 2];
   const resultArr = deepMerge(originalArr, [3, 4], {clone: true, arrayExtend: true});
@@ -65,10 +73,11 @@ test("deepMerge", () => {
   expect(originalArr).toEqual([1, 2]);
 
   const customClone = (value: any) => structuredClone(value);
-  const original2 = {a: 1, deep: {b: 2, c: 0}};
+  const original2 = {a: 1, deep: {b: 2}};
+  // @ts-expect-error 'c' is not a key of `deep`
   const result2 = deepMerge(original2, {a: 2, deep: {c: 3}}, {clone: customClone});
   expect(result2).toEqual({a: 2, deep: {b: 2, c: 3}});
-  expect(original2).toEqual({a: 1, deep: {b: 2, c: 0}});
+  expect(original2).toEqual({a: 1, deep: {b: 2}});
 });
 
 test("deepMerge type: rejects keys not in target", () => {

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ type DeepieMergeOpts<T = any> = {
   /** Maximum recursions to perform. Default: 10. */
   maxRecursion?: number,
   /** Return a new value instead of mutating the first argument. Default: false */
-  clone?: boolean | ((value: T) => T),
+  clone?: boolean | ((value: NoInfer<T>) => NoInfer<T>),
 };
 
 type DeepMergeable = {[key: string]: any} | Array<any>;

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,11 @@ type DeepieMergeOpts<T = any> = {
 
 type DeepMergeable = {[key: string]: any} | Array<any>;
 
+type DeepPartial<T> =
+  T extends Array<infer U> ? Array<DeepPartial<U>> :
+    T extends object ? {[K in keyof T]?: DeepPartial<T[K]>} :
+      T;
+
 function isObject(obj: any): boolean {
   return Object.prototype.toString.call(obj) === "[object Object]";
 }
@@ -22,7 +27,7 @@ function getType(obj: any): string {
 }
 
 /** deep-merge b into a */
-export function deepMerge<T extends DeepMergeable>(a: T, b: any, {arrayExtend = false, maxRecursion = 20, clone = false}: DeepieMergeOpts<T> = {arrayExtend: false, maxRecursion: 10}): T {
+export function deepMerge<T extends DeepMergeable>(a: T, b: DeepPartial<T> | null | undefined, {arrayExtend = false, maxRecursion = 20, clone = false}: DeepieMergeOpts<T> = {arrayExtend: false, maxRecursion: 10}): T {
   return merge(clone ? (typeof clone === "function" ? clone(a) : structuredClone(a)) : a, b, arrayExtend, maxRecursion) as T;
 }
 


### PR DESCRIPTION
Replace `b: any` with `b: DeepPartial<T> | null | undefined`, pinning `T` from the first argument and constraining the second to a deep partial of it. Excess or mistyped keys are now caught at the call site.

### Why

The `b: any` signature silently accepted any shape, so bugs like passing a key not in `T` slipped through:

```ts
deepMerge(config, {pnpm: "^10"}); // wanted to pin a dep but `pnpm` isn't a Config root key
```

Compared to other libs:
- `lodash.merge` / `merge-deep`: `T & U` intersection — accepts anything.
- TehShrike `deepmerge`: `Partial<T>` overload, but a second `<T1, T2>` overload re-opens the door.
- `deepmerge-ts` / `defu`: complex variadic HKT — overkill for this library.

`DeepPartial<T>` pinned by the first argument is the simplest signature that catches the bug.

### Breaking changes

- Heterogeneous merge of arrays into objects (and vice versa) no longer type-checks.
- Adding new sub-keys via merge no longer type-checks; declare them as optional on the destination type instead.
- `null`/`undefined` as the destination is no longer accepted; only the source argument.

Tests: existing runtime behaviour preserved; two `@ts-expect-error` cases lock in the new strictness.

---
This PR was written with the help of Claude Opus 4.7